### PR TITLE
pyproject.toml: Remove redundant "wheel" requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
The explicit requirement of "wheel" is not necessary since setuptools'
build-backend adds it automatically, and it has been removed from
the documentation in recent setuptools versions.