### PR TITLE
Fix invalidate_caches type error

### DIFF
--- a/src/editables/redirector.py
+++ b/src/editables/redirector.py
@@ -37,3 +37,11 @@ class RedirectingFinder(importlib.abc.MetaPathFinder):
                 break
         else:
             sys.meta_path.append(cls)
+
+    @classmethod
+    def invalidate_caches(cls) -> None:
+        # importlib.invalidate_caches calls finders' invalidate_caches methods,
+        # and since we install this meta path finder as a class rather than an instance,
+        # we have to override the inherited invalidate_caches method (using self)
+        # as a classmethod instead
+        pass

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -1,4 +1,5 @@
 import contextlib
+import importlib
 import sys
 
 from editables.redirector import RedirectingFinder as F
@@ -81,3 +82,10 @@ def test_redirects(tmp_path):
         import pkg.sub
 
         assert pkg.sub.val == 42
+
+
+def test_cache_invalidation():
+    F.install()
+    # assert that the finder matches importlib's expectations
+    # see https://github.com/pfmoore/editables/issues/31
+    importlib.invalidate_caches()


### PR DESCRIPTION
Closes #31.

Since you explicitly install the finder as a class, I went with the classmethod override solution.