### PR TITLE
Add support for redirecting for a namespace package.

### DIFF
--- a/src/editables/redirector.py
+++ b/src/editables/redirector.py
@@ -19,10 +19,6 @@ class RedirectingFinder(importlib.abc.MetaPathFinder):
     def find_spec(
         cls, fullname: str, path: ModulePath = None, target: Optional[ModuleType] = None
     ) -> Optional[importlib.machinery.ModuleSpec]:
-        if "." in fullname:
-            return None
-        if path is not None:
-            return None
         try:
             redir = cls._redirections[fullname]
         except KeyError:

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -84,6 +84,30 @@ def test_redirects(tmp_path):
         assert pkg.sub.val == 42
 
 
+def test_namespace_redirects(tmp_path):
+    project = tmp_path / "project"
+    project_files = {
+        "ns.pkg": {
+            "__init__.py": "val = 42",
+            "sub.py": "val = 42",
+        }
+    }
+    build(project, project_files)
+
+    # Redirector is not responsible for ensuring that "ns" exists
+    build(tmp_path / "site-packages", {"ns": {}})
+
+    with save_import_state():
+        sys.path.append(str(tmp_path / "site-packages"))
+        F.install()
+        F.map_module("ns.pkg", project / "ns.pkg" / "__init__.py")
+
+        import ns.pkg.sub
+
+        assert ns.pkg.val == 42
+        assert ns.pkg.sub.val == 42
+
+
 def test_cache_invalidation():
     F.install()
     # assert that the finder matches importlib's expectations


### PR DESCRIPTION
This alternative to #35 simply provides redirects for submodules if not found by other finders.
