### PR TITLE
Centralize on the pth-free __init__.py method, no "unnecessary change" version

### DIFF
--- a/src/editables/__init__.py
+++ b/src/editables/__init__.py
@@ -32,6 +32,51 @@ class EditableException(Exception):
     pass
 
 
+def _init_py(abs_target: Union[str, os.PathLike]) -> str:
+    abs_target = Path(abs_target)
+    is_package = abs_target.name == "__init__.py"
+    return f"""# Editables' module redirector
+file = {repr(str(abs_target))}
+__path__ = [{repr(str(abs_target.parent))}]
+
+# Symlink for faster startup next time, inspired by `flit install -s`.
+# Ignoring uninstallation for packages for now as it's complicated,
+# but reinstalling without editability will overwrite the symlink
+# and it'll be uninstalled fine after.
+import os
+try:
+    {"os.symlink(__path__[0], __file__[:-3])" if is_package
+     else "os.symlink(file, __file__ + '.new')\n"
+     + "    os.rename(__file__ + '.new', __file__)"}
+except OSError:
+    __file__ = file # Please enable Developer Mode on Windows
+del os
+{"del __path__ # Is module not package" if not is_package
+    else "__package__ = __name__\n" # Is package, so allow relative imports
+    + "__spec__.submodule_search_locations = __path__"}
+
+# Load from actual source of editable module
+import io
+try:
+    with io.open_code(file) as file:
+        file = file.read()
+except OSError:
+    file = ""
+{"    raise # Module files should always exist" if not is_package
+    else "pass # Support implicit namespace packages"}
+del io
+
+# Undo global namespace pollution before invoking actual module
+def cleanup():
+    global cleanup, file
+    del cleanup, file
+    return True
+
+(lambda _file, _globals, _locals:
+    cleanup() and _file and exec(_file, _globals, _locals))(file, globals(), locals())
+"""
+
+
 class EditableProject:
     def __init__(self, project_name: str, project_dir: Union[str, os.PathLike]) -> None:
         if not is_valid(project_name):
@@ -42,11 +87,22 @@ class EditableProject:
         self.redirections: Dict[str, str] = {}
         self.path_entries: List[Path] = []
         self.subpackages: Dict[str, Path] = {}
+        self._files: Dict[str, str] = {}
 
     def make_absolute(self, path: Union[str, os.PathLike]) -> Path:
         return (self.project_dir / path).resolve()
 
     def map(self, name: str, target: Union[str, os.PathLike]) -> None:
+        while name.startswith("."):
+            name = name.removeprefix(".")
+        if name == "__pycache__":
+            return
+        name = os.path.join(*name.split("."))
+        abs_target = self.make_absolute(target)
+        if abs_target.is_dir():
+            abs_target = abs_target / "__init__.py"
+        self._files[str(Path(name + ".py"))] = _init_py(abs_target)
+        return
         if "." in name:
             raise EditableException(
                 f"Cannot map {name} as it is not a top-level package"
@@ -60,12 +116,24 @@ class EditableProject:
             raise EditableException(f"{target} is not a valid Python package or module")
 
     def add_to_path(self, dirname: Union[str, os.PathLike]) -> None:
-        self.path_entries.append(self.make_absolute(dirname))
+        with os.scandir(self.project_dir / dirname) as entries:
+            for entry in entries:
+                name = entry.name
+                target = os.path.join(dirname, name)
+                if entry.is_dir():
+                    target = os.path.join(target, "__init__.py")
+                elif entry.is_file() and name.endswith(".py"):
+                    name = name[:-3]
+                else:
+                    continue
+                self.map(name, target)
 
     def add_to_subpackage(self, package: str, dirname: Union[str, os.PathLike]) -> None:
-        self.subpackages[package] = self.make_absolute(dirname)
+        self.map(package, self.make_absolute(dirname) / "__init__.py")
 
     def files(self) -> Iterable[Tuple[str, str]]:
+        yield from self._files.items()
+        return
         yield f"{self.project_name}.pth", self.pth_file()
         if self.subpackages:
             for package, location in self.subpackages.items():


### PR DESCRIPTION
#40 is the only version that should be merged, not this.

@pfmoore was uncomfortable because the real PR had `10 files changed, 224 insertions(+), 358 deletions(-)`, which https://github.com/pfmoore/editables/pull/40#issuecomment-4183433631 called:

> [...] There's a *lot* of what feels like unnecessary change here, and I don't have the time (or frankly the inclination) to review AI generated code.
>
> I'll be blunt here - as it stands, this code seems borderline unmaintainable compared to the existing code.

This PR is to provide a Git diff that is smaller to review thus not appear "borderline unmaintainable". The test suite from the real PR passes here, but is not included. Dead code removal and documentation changes are similarly omitted.

The point of this PR is to show that avoiding `.pth` can be achieved in only `1 file changed, 70 insertions(+), 2 deletions(-)`. I hope this addresses what was considered "a *lot* of what feels like unnecessary change here", and that the highlighting of important areas in this PR makes the other PR easier to review.